### PR TITLE
Pull in lein-pallet-crate for the crate-doc task

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -3,7 +3,8 @@
         [com.palletops/crates "0.1.0"]
         [ch.qos.logback/logback-classic "1.0.9"]]
        :plugins [[lein-set-version "0.3.0"]
-                 [lein-resource "0.3.2"]
+                 [lein-resource "0.3.2" :exclusions [stencil]]
+                 [com.palletops/lein-pallet-crate "0.1.0"]
                  [codox/codox.leiningen "0.6.4"]
                  [lein-marginalia "0.7.1"]]
        :aliases {"live-test-up"


### PR DESCRIPTION
Before this commit:
    $ lein test
    Copy doc-src/USAGE.md to target/classes/pallet_crate/java_crate/USAGE.md
    'crate-doc' is not a task. See 'lein help'.
    Tests failed.
