### PR TITLE
Pull in pallet-lein in the project profile

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -4,6 +4,7 @@
         [ch.qos.logback/logback-classic "1.0.9"]]
        :plugins [[lein-set-version "0.3.0"]
                  [lein-resource "0.3.2" :exclusions [stencil]]
+                 [com.palletops/pallet-lein "0.6.0-beta.6"]
                  [com.palletops/lein-pallet-crate "0.1.0"]
                  [codox/codox.leiningen "0.6.4"]
                  [lein-marginalia "0.7.1"]]


### PR DESCRIPTION
Without this fix in place (and no mention of pallet-lein in the user profile), one gets this error:

```
$ lein live-test
'pallet' is not a task. See 'lein help'.
```

With this change, lein-pedantic gives a warning. I didn't figure out how to get lein-pedantic to be happy.
